### PR TITLE
cclq: a small binary to run queries on ccl documents

### DIFF
--- a/bin/cclq.ml
+++ b/bin/cclq.ml
@@ -1,0 +1,63 @@
+(* simple queries for ccl *)
+
+module Params
+: sig
+  val files : string Seq.t
+  val queries : string list list
+end
+= struct
+  let files, queries =
+    match Sys.argv with
+    | [| name; "--help" |] ->
+        Format.printf
+          "%s [file [file ..]] <query>\n\
+           %s [file [file ..]] -- [query [query ..]]\n\
+           Query values in CCL files.\n\
+           Queries are '='-separated list of keys."
+          name name;
+        exit 0
+    | [| _ |] ->
+      (Seq.return "/dev/stdin", [[]])
+    | _ -> match Array.find_index (String.equal "--") Sys.argv with
+      | None ->
+        let files = Array.to_seq (Array.sub Sys.argv 1 (Array.length Sys.argv - 2)) in
+        let query = String.split_on_char '=' Sys.argv.(Array.length Sys.argv - 1) in
+        (files, [query])
+      | Some i ->
+        let files = Array.to_seq (Array.sub Sys.argv 1 (i - 1)) in
+        let queries =
+          if i = Array.length Sys.argv - 1 then
+            (* no queries: default query is print all *)
+            [[]]
+          else
+            Array.sub Sys.argv (i + 1) (Array.length Sys.argv - i - 1)
+            |> Array.to_list
+            |> List.map (String.split_on_char '=')
+        in
+        (files, queries)
+end
+
+let load files =
+  files
+  |> Seq.map Ccl.decode_file
+  |> Seq.map Result.get_ok
+  |> Seq.fold_left Ccl.Model.merge Ccl.Model.empty
+
+let rec query keys ccl =
+  match keys with
+  | [] -> ccl
+  | key :: keys ->
+      let (Ccl.Model.Fix ccl) = ccl in
+      match Ccl.Model.KeyMap.find_opt key ccl with
+      | None -> raise Not_found
+      | Some ccl -> query keys ccl
+
+let () =
+  let ccl = load Params.files in
+  List.iter
+    (fun q ->
+      ccl
+      |> query q
+      |> Ccl.Model.pretty
+      |> print_endline)
+    Params.queries

--- a/bin/cclq.ml
+++ b/bin/cclq.ml
@@ -18,6 +18,9 @@ end
         exit 0
     | [| _ |] ->
       (Seq.return "/dev/stdin", [[]])
+    | [| _; query |] ->
+      let query = String.split_on_char '=' query in
+      (Seq.return "/dev/stdin", [query])
     | _ -> match Array.find_index (String.equal "--") Sys.argv with
       | None ->
         let files = Array.to_seq (Array.sub Sys.argv 1 (Array.length Sys.argv - 2)) in

--- a/bin/dune
+++ b/bin/dune
@@ -1,4 +1,5 @@
 (executable
- (public_name ccl)
- (name main)
+ (public_name cclq)
+ (name cclq)
+ (package ccl)
  (libraries ccl))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,1 +1,0 @@
-let () = print_endline "Doing nothing..."

--- a/test/cclq-cram/dune
+++ b/test/cclq-cram/dune
@@ -1,0 +1,1 @@
+(cram (deps %{bin:cclq}))

--- a/test/cclq-cram/merge-query.t
+++ b/test/cclq-cram/merge-query.t
@@ -53,3 +53,7 @@ Merge and queries
   
   baz =
   
+Pipe queries
+  $ cat sample2.ccl | cclq this | cclq bar
+  baz =
+  

--- a/test/cclq-cram/merge-query.t
+++ b/test/cclq-cram/merge-query.t
@@ -1,0 +1,55 @@
+Produce sample
+  $ cat >sample1.ccl <<EOF
+  > numbers =
+  >   foo = 12341234
+  >   bar = 12341233
+  >   baz = 12341236
+  > EOF
+
+Produce more sample
+  $ cat >sample2.ccl <<EOF
+  > numbers =
+  >   baz = 123
+  >   foo = 1
+  > somekey = someval
+  > this =
+  >   that =
+  >   foo =
+  >   bar = baz
+  > EOF
+
+Merge
+  $ cclq sample1.ccl sample2.ccl --
+  numbers =
+    bar =
+      12341233 =
+    baz =
+      123 =
+      12341236 =
+    foo =
+      1 =
+      12341234 =
+  somekey =
+    someval =
+  this =
+    bar =
+      baz =
+    foo =
+    that =
+  
+
+Merge and query
+  $ cclq sample1.ccl sample2.ccl -- numbers=foo
+  1 =
+  12341234 =
+  
+
+Merge and queries
+  $ cclq sample1.ccl sample2.ccl -- numbers=foo somekey this=bar
+  1 =
+  12341234 =
+  
+  someval =
+  
+  baz =
+  


### PR DESCRIPTION
The new `cclq` binary:
- consumes and prints ccl documents
- can consume multiple documents in which case it performs merging
- can find a value (or a sub-document) by passing a series of keys

Examples:
```
cclq example.ccl user=guestId
cat example.ccl | cclq user | cclq createdAt
cclq example.ccl -- database=enabled database=ports=
```