### PR TITLE
Add Rust implementations to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,11 @@ Install dev dependencies:
 ```
 opam install utop ocamlformat ocaml-lsp-server
 ```
+
+## Implementations in Other Languages
+
+### Rust
+
+- [ccl-rs](https://github.com/hon-gyu/ccl-rs)
+
+- [serde_ccl](https://github.com/LechintanTudor/serde_ccl)


### PR DESCRIPTION
Adds an "Implementations" section to the README documenting the available Rust implementations of CCL (`ccl-rs` and `serde_ccl`). 

Closes #4 